### PR TITLE
Bug Fix: Remove custom crests' slots from Eva progression

### DIFF
--- a/Data/CrestData.cs
+++ b/Data/CrestData.cs
@@ -23,6 +23,12 @@ namespace Needleforge.Data
         public string name = "";
         public bool UnlockedAtStart = true;
 
+        /// <summary>
+        /// Sets whether or not this crest's tool slots count towards Eva's unlocks
+        /// and quest progression. Default is <see langword="false"/>.
+        /// </summary>
+        public bool slotsCountForEvaQuest = false;
+
         public LocalisedString displayName;
         public LocalisedString description;
 

--- a/Patches/EvaProgressionOptOut.cs
+++ b/Patches/EvaProgressionOptOut.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using HutongGames.PlayMaker.Actions;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Needleforge.Patches;
+
+[HarmonyPatch(typeof(CountCrestUnlockPoints), nameof(CountCrestUnlockPoints.OnEnter))]
+internal static class EvaProgressionOptOut
+{
+    private static void Prefix(CountCrestUnlockPoints __instance)
+    {
+        ToolCrestList list = ScriptableObject.CreateInstance<ToolCrestList>();
+
+        HashSet<ToolCrest> crestsToRemove = [..
+            from x in NeedleforgePlugin.newCrestData
+            where !x.slotsCountForEvaQuest
+            select x.ToolCrest!
+        ];
+
+        foreach (ToolCrest crest in (ToolCrestList)__instance.CrestList.Value)
+        {
+            if (!crestsToRemove.Contains(crest))
+                list.Add(crest);
+        }
+
+        __instance.CrestList.Value = list;
+    }
+}


### PR DESCRIPTION
Slots on custom crests by default no longer count towards the progression of Eva's questline. If a custom crest wants its slots to count towards it, this can be changed by setting the field `CrestData.slotsCountForEvaQuest` to `true`.

Closes: #21 